### PR TITLE
SwiftTaskの返り値をtypealiasとして拡張しました。

### DIFF
--- a/Balblair/SwiftTask/Classes/ApiRequest+SwiftTask.swift
+++ b/Balblair/SwiftTask/Classes/ApiRequest+SwiftTask.swift
@@ -54,3 +54,7 @@ extension ApiRequest where ResultType: _ArrayType, ResultType.Element: Mappable,
     }
   }
 }
+
+extension ApiRequest {
+  public typealias TaskType = Task<NSProgress, ResultType, ErrorModelType>
+}


### PR DESCRIPTION
タスクだけを返すメソッドを定義する場合に、`Request.TaskType`を返り値として指定することでTaskの定義を省略することが出来ます。
Success/Failureを呼び出し元で利用する場合が多い気がするのであってもいいかなと思うのですが、如何でしょうか。

before:

``` swift
func putTwitterAccounts(accessToken: String, accessTokenSecret: String) -> Task<NSProgress, TwitterAccountsRequest.ResultType, TwitterAccountsRequest.ErrorModelType> {
    return TwitterAccountsRequest().createTask()
}
```

after:

``` swift
func putTwitterAccounts(accessToken: String, accessTokenSecret: String) -> TwitterAccountsRequest.TaskType {
    return TwitterAccountsRequest().createTask()
}
```
